### PR TITLE
Add 'Measure Speed' Button and Auto-Calculate Feature

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,18 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "macos-latest" # for Arm-based Macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
-            rust-target: "aarch64-apple-darwin"
-          - platform: "macos-latest" # for Intel-based Macs.
-            args: "--target x86_64-apple-darwin"
-            rust-target: "x86_64-apple-darwin"
-          - platform: "ubuntu-22.04" # for Ubuntu (Tauri v2)
-            args: "--target x86_64-unknown-linux-gnu"
-            rust-target: "x86_64-unknown-linux-gnu"
-          - platform: "windows-latest" # for Windows
-            args: "--target x86_64-pc-windows-msvc"
-            rust-target: "x86_64-pc-windows-msvc"
+        - platform: "macos-latest" # for Arm-based Macs (M1 and above).
+          args: "--target aarch64-apple-darwin"
+          rust-target: "aarch64-apple-darwin"
+        - platform: "macos-latest" # for Intel-based Macs.
+          args: "--target x86_64-apple-darwin"
+          rust-target: "x86_64-apple-darwin"
+        - platform: "ubuntu-22.04" # for Ubuntu (Tauri v2)
+          args: "--target x86_64-unknown-linux-gnu"
+          rust-target: "x86_64-unknown-linux-gnu"
+        - platform: "windows-latest" # for Windows
+          args: "--target x86_64-pc-windows-msvc"
+          rust-target: "x86_64-pc-windows-msvc"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -64,4 +64,5 @@ jobs:
           releaseBody: "This is the official release of DTime version __VERSION__." # The release notes.
           releaseDraft: false # Set to true if you want to create a draft release.
           prerelease: false # Set to true if this is a pre-release.
+          generateReleaseNotes: true # Automatically generate release notes based on commits and PRs.
           args: ${{ matrix.args }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "dtime"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "cfspeedtest",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtime"
-version = "1.0.1"
+version = "1.0.2"
 description = "DTime"
 authors = ["Sebastian Steffensen"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "DTime",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "sfsteffensen.dev",
   "build": {
     "beforeDevCommand": "yarn run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,10 +76,16 @@ function App() {
 
       const unitInput = document.getElementById("internet-speed-unit") as HTMLSelectElement;
       if (unitInput) unitInput.value = "mbps";
+
+      // Automatically run the calculate function if file size and unit are set
+      if (fileSize() && fileSizeUnit()) {
+        await calculate();
+      }
     } finally {
       setLoadingSpeedTest(false);
     }
   }
+
 
   return (
     <div class="flex items-center justify-center min-h-screen bg-base-100 text-base-content">
@@ -124,7 +130,7 @@ function App() {
               {loadingCalculate() ? "Calculating..." : "Calculate"}
             </button>
             <button type="button" class="btn btn-outline btn-primary flex-1" onClick={testSpeed} disabled={loadingSpeedTest()}>
-              {loadingSpeedTest() ? "Testing..." : "Test Speed"}
+              {loadingSpeedTest() ? "Measuring Speed..." : "Measure Speed"}
             </button>
           </div>
         </form>


### PR DESCRIPTION
# This PR introduces the following improvements:

- Button Renaming: The 'Test Speed' button has been renamed to 'Measure Speed' for better clarity and user understanding.

- Auto-Calculation Feature: After measuring the internet speed, if a file size and unit have been provided, the app will automatically calculate the download time without requiring additional user input.